### PR TITLE
Fix tag links urlize

### DIFF
--- a/layouts/partials/posts.html
+++ b/layouts/partials/posts.html
@@ -45,7 +45,7 @@
             <div class="f6 text-gray mt-2 text-mono">
               {{ with .Params.tags }}
               {{ range $tag := (first 5 .) }}
-              <a class="muted-link mr-3" href="{{ relURL (print " /tags/" . | urlize) }}">
+              <a class="muted-link mr-3" href="{{ relURL (print "/tags/" . | urlize) }}">
                 <svg class="octicon octicon-tag" viewBox="0 0 16 16" version="1.1" width="16" height="16">
                   <path fill-rule="evenodd"
                     d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z">

--- a/themes/github-style/layouts/partials/posts.html
+++ b/themes/github-style/layouts/partials/posts.html
@@ -45,7 +45,7 @@
             <div class="f6 text-gray mt-2">
               {{ with .Params.tags }}
               {{ range $tag := (first 5 .) }}
-              <a class="muted-link mr-3" href="{{ relURL (print " /tags/" . | urlize) }}">
+              <a class="muted-link mr-3" href="{{ relURL (print "/tags/" . | urlize) }}">
                 <svg class="octicon octicon-tag" viewBox="0 0 16 16" version="1.1" width="16" height="16">
                   <path fill-rule="evenodd"
                     d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z">


### PR DESCRIPTION
## Summary
- avoid leading spaces in tag links for urlize

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c670c4e8832eabd138c38f4d8405