### PR TITLE
move tag padding to css

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,6 +1,3 @@
-<style>
-	.tags { padding: 15px 0; }
-</style>
 <div class="f6 text-gray mt-2 tags border-bottom text-mono">
 	{{ range $taxonomy, $terms := site.Taxonomies }}
 	{{ range $term := $terms }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -141,3 +141,7 @@ article .taped-image {
   word-break: keep-all;
   overflow-wrap: break-word;
 }
+
+.tags {
+  padding: 15px 0;
+}

--- a/themes/github-style/layouts/partials/tags.html
+++ b/themes/github-style/layouts/partials/tags.html
@@ -1,6 +1,3 @@
-<style>
-	.tags { padding: 15px 0; }
-</style>
 <div class="f6 text-gray mt-2 tags border-bottom">
 	{{ range $taxonomy, $terms := site.Taxonomies }}
 	{{ range $term := $terms }}


### PR DESCRIPTION
## Summary
- remove inline `.tags` style from layout partials
- add `.tags` rule to custom stylesheet

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c788e448832e8d7bd58059feff6f