### PR TITLE
Fix stray style attribute in navigation partial

### DIFF
--- a/layouts/partials/menus.html
+++ b/layouts/partials/menus.html
@@ -1,5 +1,7 @@
 {{ $section := where .Site.RegularPages "Section" "in" (slice "notas") }}
 {{ $section_count := len $section }}
+
+<div class="mt-4 position-sticky top-0 d-none d-md-block bg-white width-full border-bottom color-border-secondary"
   style="z-index:3;">
   <div class="container-xl px-3 px-md-4 px-lg-5">
     <div class="gutter-condensed gutter-lg flex-column flex-md-row d-flex">


### PR DESCRIPTION
## Summary
- fix stray `style="z-index:3;"` line in `menus.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876d37f89e8832e98ea19674eb298da