### PR TITLE
fix: make sidebar sticky above header

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -149,5 +149,7 @@ article .taped-image {
     top: 0;
     height: 100vh;
     overflow-y: auto;
+    z-index: 4;
+    align-self: flex-start;
   }
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -149,5 +149,7 @@ article .taped-image {
     top: 0;
     height: 100vh;
     overflow-y: auto;
+    z-index: 4;
+    align-self: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- keep sidebar fixed while scrolling and display it above the header

## Testing
- `hugo --destination docs`


------
https://chatgpt.com/codex/tasks/task_e_6890a140bc00832eba3997151b7801bb