### PR TITLE
fix: pin sidebar above header

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -145,9 +145,20 @@ article .taped-image {
 
 @media (min-width: 768px) {
   #sidebar {
-    position: sticky;
+    position: fixed;
     top: 0;
+    width: 260px;
     height: 100vh;
     overflow-y: auto;
+    z-index: 5;
+  }
+
+  #headerImg {
+    position: relative;
+    z-index: 6;
+  }
+
+  #sidebar + .flex-shrink-0 {
+    margin-left: 280px;
   }
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -145,9 +145,20 @@ article .taped-image {
 
 @media (min-width: 768px) {
   #sidebar {
-    position: sticky;
+    position: fixed;
     top: 0;
+    width: 260px;
     height: 100vh;
     overflow-y: auto;
+    z-index: 5;
+  }
+
+  #headerImg {
+    position: relative;
+    z-index: 6;
+  }
+
+  #sidebar + .flex-shrink-0 {
+    margin-left: 280px;
   }
 }


### PR DESCRIPTION
## Summary
- ensure sidebar stays fixed to viewport and sits above the header
- shrink sidebar width and offset main content to sit beside it

## Testing
- `hugo --destination docs`


------
https://chatgpt.com/codex/tasks/task_e_6890a140bc00832eba3997151b7801bb