### PR TITLE
Ajusta layout dos separadores superiores

### DIFF
--- a/themes/minimal-garden/static/css/style.css
+++ b/themes/minimal-garden/static/css/style.css
@@ -318,12 +318,12 @@ article .taped-image {
 
 .bookmark-menu {
   position: absolute;
-  top: -1.2rem; /* colado ao topo da folha */
+  top: 2.2rem; /* escondidas atrás da folha */
   left: 50%;
   transform: translateX(-50%);
   display: flex;
   gap: 0.5rem;
-  z-index: 3;
+  z-index: 0; /* atrás do conteúdo */
 }
 
 .bookmark {
@@ -336,13 +336,14 @@ article .taped-image {
   color: black;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   position: relative;
-  top: 0;
+  top: 0; /* parte escondida atrás da folha */
   transition: top 0.1s ease;
-  z-index: 3;
+  z-index: 0;
 }
 
-.bookmark:hover {
-  top: 10px;
+.bookmark:hover,
+.bookmark.active {
+  top: -0.5rem; /* aparece um pouco mais */
 }
 
 .bookmark.entrada {
@@ -355,7 +356,3 @@ article .taped-image {
   color: white;
 }
 
-.bookmark.active {
-  top: -0.3rem; /* levanta o separador ativo */
-  z-index: 3;
-}


### PR DESCRIPTION
## Summary
- Ajusta o menu de separadores para surgir por trás da caixa de conteúdo
- Destaca separadores ativos e em foco elevando-os ligeiramente

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68912dd43378832eac9e2352ba57b608