### PR TITLE
Estilo colado para itens de notas

### DIFF
--- a/themes/minimal-garden/layouts/notas/list.html
+++ b/themes/minimal-garden/layouts/notas/list.html
@@ -1,0 +1,30 @@
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+
+  <ul class="post-list">
+    {{ range $i, $p := .Pages.ByDate.Reverse }}
+      {{ $seed := add now.UnixNano $i }}
+      {{ $rot := mod $seed 7 | sub 3 | float }}
+      {{ $top := mod (add $seed 11) 40 | add 10 }}
+      {{ $bottom := mod (add $seed 23) 40 | add 10 }}
+      {{ $rotTop := mod (add $seed 37) 10 | sub 5 | float }}
+      {{ $rotBottom := mod (add $seed 51) 10 | sub 5 | float }}
+      <li class="taped-note" style="--rotacao-img: {{ $rot }}deg; --pos-topo: {{ $top }}%; --pos-fundo: {{ $bottom }}%; --rotacao-topo: {{ $rotTop }}deg; --rotacao-fundo: {{ $rotBottom }}deg;">
+        <div class="taped-shadow">
+          <div class="taped-note-content">
+            <a class="post-title" href="{{ $p.RelPermalink }}">{{ $p.Title }}</a>
+            {{ with $p.Date }}
+              <time datetime="{{ . }}">{{ .Format "02/01/2006" }}</time>
+            {{ end }}
+            {{ with $p.Summary }}
+              <p>{{ . }}</p>
+            {{ else }}
+              {{ $summary := $p.Plain | truncate 160 }}
+              <p>{{ $summary }}</p>
+            {{ end }}
+          </div>
+        </div>
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/themes/minimal-garden/static/css/style.css
+++ b/themes/minimal-garden/static/css/style.css
@@ -311,6 +311,65 @@ article .taped-image {
   transform: rotate(var(--rotacao-fundo, 5deg));
 }
 
+.taped-note {
+  position: relative;
+  display: block;
+  margin: 2em 0;
+  width: 100%;
+  box-sizing: border-box;
+  transform: rotate(var(--rotacao-img, -0.4deg));
+}
+
+.taped-note .taped-shadow {
+  display: block;
+  filter: drop-shadow(3px 4px 8px rgba(0, 0, 0, 0.12));
+}
+
+.taped-note-content {
+  background: url("/images/papel-envelhecido-textura.png") repeat;
+  background-position: center top;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 1.5rem;
+  clip-path: polygon(var(--p1x, 3%) var(--p1y, 0%),
+      var(--p2x, 97%) var(--p2y, 1%),
+      var(--p3x, 100%) var(--p3y, 5%),
+      var(--p4x, 99%) var(--p4y, 95%),
+      var(--p5x, 96%) var(--p5y, 100%),
+      var(--p6x, 4%) var(--p6y, 99%),
+      var(--p7x, 0%) var(--p7y, 95%),
+      var(--p8x, 1%) var(--p8y, 5%));
+}
+
+.taped-note::before,
+.taped-note::after {
+  content: '';
+  position: absolute;
+  width: 90px;
+  height: 28px;
+  background: repeating-linear-gradient(45deg,
+      rgba(240, 220, 150, 0.85),
+      rgba(240, 220, 150, 0.85) 10px,
+      rgba(235, 210, 140, 0.8) 10px,
+      rgba(235, 210, 140, 0.8) 20px);
+  opacity: 0.9;
+  z-index: 2;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+}
+
+.taped-note::before {
+  top: -14px;
+  left: var(--pos-topo, 12%);
+  transform: rotate(var(--rotacao-topo, -5deg));
+}
+
+.taped-note::after {
+  bottom: -14px;
+  right: var(--pos-fundo, 14%);
+  transform: rotate(var(--rotacao-fundo, 5deg));
+}
+
 .bookmark-menu {
   position: absolute;
   top:-15px;


### PR DESCRIPTION
## Resumo
- Adiciona template `list` para notas com itens tipo recorte de papel e fita-cola
- Introduz classes CSS `taped-note` para fundo de papel, sombra e fitas

## Testes
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6892744d5544832eb85d86445537f645